### PR TITLE
Issue #17: [UX] Devel Generate: Menus: Move the "Create new menu(s)" …

### DIFF
--- a/devel_generate/devel_generate.module
+++ b/devel_generate/devel_generate.module
@@ -391,7 +391,7 @@ function devel_generate_set_message($msg, $type = 'status') {
 function devel_generate_menu_form() {
   $menu_enabled = module_exists('menu');
   if ($menu_enabled) {
-    $menus = array('__new-menu__' => t('Create new menu(s)')) + menu_get_menus();
+    $menus = menu_get_menus() + array('__new-menu__' => t('Create new menu(s)'));
   }
   else {
     $menus = menu_list_system_menus();


### PR DESCRIPTION
…option after the existing menus checkboxes.

Fixes https://github.com/backdrop-contrib/devel/issues/17
