### PR TITLE
Issue #23: Yet another follow-up PR

### DIFF
--- a/devel.module
+++ b/devel.module
@@ -681,12 +681,12 @@ function devel_block_info() {
   $blocks['execute_php'] = array(
     'info' => t('Execute PHP'),
     'cache' => BACKDROP_NO_CACHE,
-    'description' => '<strong>' . t('Dangerous!') . '</strong> ' . t('Execute arbitrary PHP code from a block. Requires the <i>Execute PHP code</i> permission.'),
+    'description' => '<strong>' . t('Dangerous!') . '</strong> ' . t('Execute arbitrary PHP code from a block. Requires the <em>Execute PHP code</em> permission.'),
   );
   $blocks['switch_user'] = array(
     'info' => t('Switch user'),
     'cache' => BACKDROP_NO_CACHE,
-    'description' => '<strong>' . t('Dangerous!') . '</strong> ' . t('Allows switching between any user account on the site. Requires the <i>Switch users</i> permission.'),
+    'description' => '<strong>' . t('Dangerous!') . '</strong> ' . t('Allows switching between any user account on the site. Requires the <em>Switch users</em> permission.'),
   );
   return $blocks;
 }


### PR DESCRIPTION
@quickscetch, https://github.com/backdrop-contrib/devel/pull/25#issuecomment-269882995 :

> Actually, we use `em` tags for italics, not `i`. I made yet another quick follow-up commit.