### PR TITLE
Update devel_node_access.module

### DIFF
--- a/devel_node_access/devel_node_access.module
+++ b/devel_node_access/devel_node_access.module
@@ -467,6 +467,8 @@ function devel_node_access_block_view($delta) {
   global $user;
   global $theme_key;
   static $block1_visible, $hint = '';
+  $block1_visible = true;
+  /*
   if (!isset($block1_visible)) {
     $block1_visible = db_query("SELECT status FROM {block} WHERE module = 'devel_node_access' AND delta = 'dna_user' AND theme = :theme", array(
       ':theme' => $theme_key,
@@ -475,7 +477,7 @@ function devel_node_access_block_view($delta) {
       $hint = t('For per-user access permissions enable the <a href="@link">%DNAbU block</a>.', array('@link' => url('admin/structure/block'), '%DNAbU' => t('Devel Node Access by User')));
     }
   }
-
+  */
   if (!user_access(DNA_ACCESS_VIEW)) {
     return;
   }


### PR DESCRIPTION
Deactivating database call to block table which doesn't  exists any more in backdrop. This prevents this module to work and triggers a 500 error when viewing a page with the node access block. This may not be the best approach to fix this, but at least it's usable.

This fixes #29 