### PR TITLE
File generation should use `file_unmanaged_move()` instead of `file_move()` before the `file_save()` has been called.

### DIFF
--- a/devel_generate/modules/file.devel_generate.inc
+++ b/devel_generate/modules/file.devel_generate.inc
@@ -19,15 +19,20 @@ function _file_devel_generate($object, $field, $instance, $bundle) {
   if (empty($file)) {
     if ($path = devel_generate_textfile()) {
       $path_parts = explode("//", $path);
-      $source = new File();
-      $source->uri = $path;
-      $source->uid = 1; // TODO: randomize? use case specific.
-      $source->filemime = 'text/plain';
-      $source->filename = array_pop($path_parts);
+      $file = new File();
+      $file->uri = $path;
+      $file->uid = 1; // TODO: randomize? use case specific.
+      $file->filemime = 'text/plain';
+      $file->filename = array_pop($path_parts);
       $destination_dir = $field['settings']['uri_scheme'] . '://' . $instance['settings']['file_directory'];
       file_prepare_directory($destination_dir, FILE_CREATE_DIRECTORY);
       $destination = $destination_dir . '/' . basename($path);
-      $file = file_move($source, $destination, FILE_CREATE_DIRECTORY);
+      if ($file->uri = file_unmanaged_move($file->uri, $destination)) {
+        $file = file_save($file);
+      }
+      else {
+        return FALSE;
+      }
     }
     else {
       return FALSE;

--- a/devel_generate/modules/file.devel_generate.inc
+++ b/devel_generate/modules/file.devel_generate.inc
@@ -18,16 +18,17 @@ function _file_devel_generate($object, $field, $instance, $bundle) {
 
   if (empty($file)) {
     if ($path = devel_generate_textfile()) {
-      $path_parts = explode("//", $path);
-      $file = new File();
-      $file->uri = $path;
-      $file->uid = 1; // TODO: randomize? use case specific.
-      $file->filemime = 'text/plain';
-      $file->filename = array_pop($path_parts);
       $destination_dir = $field['settings']['uri_scheme'] . '://' . $instance['settings']['file_directory'];
       file_prepare_directory($destination_dir, FILE_CREATE_DIRECTORY);
-      $destination = $destination_dir . '/' . basename($path);
-      if ($file->uri = file_unmanaged_move($file->uri, $destination)) {
+
+      if ($uri = file_unmanaged_move($path, $destination_dir)) {
+        $file = new File();
+        $file->fid = NULL;
+        $file->uri = $uri;
+        $file->filename = backdrop_basename($uri);
+        $file->filemime = file_get_mimetype($file->uri);
+        // @todo Randomize file owner.
+        $file->uid = 1;
         $file = file_save($file);
       }
       else {

--- a/devel_generate/modules/file.devel_generate.inc
+++ b/devel_generate/modules/file.devel_generate.inc
@@ -20,7 +20,6 @@ function _file_devel_generate($object, $field, $instance, $bundle) {
     if ($path = devel_generate_textfile()) {
       $destination_dir = $field['settings']['uri_scheme'] . '://' . $instance['settings']['file_directory'];
       file_prepare_directory($destination_dir, FILE_CREATE_DIRECTORY);
-
       if ($uri = file_unmanaged_move($path, $destination_dir)) {
         $file = new File();
         $file->fid = NULL;

--- a/devel_generate/modules/image.devel_generate.inc
+++ b/devel_generate/modules/image.devel_generate.inc
@@ -30,16 +30,16 @@ function _image_devel_generate($object, $field, $instance, $bundle) {
   // Generate a max of 5 different images.
   if (!isset($images[$extension][$min_resolution][$max_resolution]) || count($images[$extension][$min_resolution][$max_resolution]) <= DEVEL_GENERATE_IMAGE_MAX) {
     if ($path = devel_generate_image($extension, $min_resolution, $max_resolution)) {
-      $parts = explode("//", $path);
-      $file = new File();
-      $file->uri = $path;
-      $file->uid = 1; // TODO: randomize? Use case specific.
-      $file->filemime = 'image/' . pathinfo($path, PATHINFO_EXTENSION);
-      $file->filename = array_pop($parts);
-      $destination_dir = $field['settings']['uri_scheme'] . '://' . $instance['settings']['file_directory'];
+      destination_dir = $field['settings']['uri_scheme'] . '://' . $instance['settings']['file_directory'];
       file_prepare_directory($destination_dir, FILE_CREATE_DIRECTORY);
-      $destination = $destination_dir . '/' . basename($path);
-      if ($file->uri = file_unmanaged_move($file->uri, $destination)) {
+      if ($uri = file_unmanaged_move($path, $destination_dir)) {
+        $file = new File();
+        $file->fid = NULL;
+        $file->uri = $uri;
+        $file->filename = drupal_basename($uri);
+        $file->filemime = file_get_mimetype($file->uri);
+        // @todo Randomize file owner.
+        $file->uid = 1;
         $file = file_save($file);
         $images[$extension][$min_resolution][$max_resolution][$file->fid] = $file;
       }

--- a/devel_generate/modules/image.devel_generate.inc
+++ b/devel_generate/modules/image.devel_generate.inc
@@ -31,16 +31,21 @@ function _image_devel_generate($object, $field, $instance, $bundle) {
   if (!isset($images[$extension][$min_resolution][$max_resolution]) || count($images[$extension][$min_resolution][$max_resolution]) <= DEVEL_GENERATE_IMAGE_MAX) {
     if ($path = devel_generate_image($extension, $min_resolution, $max_resolution)) {
       $parts = explode("//", $path);
-      $source = new File();
-      $source->uri = $path;
-      $source->uid = 1; // TODO: randomize? Use case specific.
-      $source->filemime = 'image/' . pathinfo($path, PATHINFO_EXTENSION);
-      $source->filename = array_pop($parts);
+      $file = new File();
+      $file->uri = $path;
+      $file->uid = 1; // TODO: randomize? Use case specific.
+      $file->filemime = 'image/' . pathinfo($path, PATHINFO_EXTENSION);
+      $file->filename = array_pop($parts);
       $destination_dir = $field['settings']['uri_scheme'] . '://' . $instance['settings']['file_directory'];
       file_prepare_directory($destination_dir, FILE_CREATE_DIRECTORY);
       $destination = $destination_dir . '/' . basename($path);
-      $file = file_move($source, $destination, FILE_CREATE_DIRECTORY);
-      $images[$extension][$min_resolution][$max_resolution][$file->fid] = $file;
+      if ($file->uri = file_unmanaged_move($file->uri, $destination)) {
+        $file = file_save($file);
+        $images[$extension][$min_resolution][$max_resolution][$file->fid] = $file;
+      }
+      else {
+        return FALSE;
+      }
     }
     else {
       return FALSE;


### PR DESCRIPTION
https://www.drupal.org/project/devel/issues/2429787

https://git.drupalcode.org/project/devel/commit/566318b758e45e9842a4185db9481eb3c7156620

and follow-up https://git.drupalcode.org/project/devel/commit/98011abf3da8023e8d4df4d7641cec2d9006d650, which has no specific issue on d.org.

https://github.com/backdrop-contrib/devel/issues/49