### PR TITLE
Wrap menu titles and descriptions in `t()`

### DIFF
--- a/devel.module
+++ b/devel.module
@@ -32,9 +32,9 @@ function devel_menu() {
    */
   $items['admin/devel/reinstall'] = array(
     'title' => t('Reinstall modules'),
+    'description' => t('Run <code>hook_uninstall()</code> and then <code>hook_install()</code> for a given module.'),
     'page callback' => 'backdrop_get_form',
     'page arguments' => array('devel_reinstall'),
-    'description' => t('Run <code>hook_uninstall()</code> and then <code>hook_install()</code> for a given module.'),
     'access arguments' => array('access devel information'),
     'file' => 'devel.pages.inc',
   );

--- a/devel.module
+++ b/devel.module
@@ -19,7 +19,7 @@ define('DEVEL_MIN_TEXTAREA', 50);
  */
 function devel_menu() {
   $items['admin/devel'] = array(
-    'title' => 'Development',
+    'title' => t('Development'),
     'access arguments' => array('access devel information'),
     'page callback' => 'system_admin_menu_block_page',
     'weight' => 5,
@@ -31,32 +31,32 @@ function devel_menu() {
    * General utilities are at the top-level.
    */
   $items['admin/devel/reinstall'] = array(
-    'title' => 'Reinstall modules',
+    'title' => t('Reinstall modules'),
     'page callback' => 'backdrop_get_form',
     'page arguments' => array('devel_reinstall'),
-    'description' => 'Run hook_uninstall() and then hook_install() for a given module.',
+    'description' => t('Run <code>hook_uninstall()</code> and then <code>hook_install()</code> for a given module.'),
     'access arguments' => array('access devel information'),
     'file' => 'devel.pages.inc',
   );
   $items['admin/devel/php'] = array(
-    'title' => 'Execute PHP Code',
-    'description' => 'Execute arbitrary PHP code.',
+    'title' => t('Execute PHP Code'),
+    'description' => t('Execute arbitrary PHP code.'),
     'page callback' => 'backdrop_get_form',
     'page arguments' => array('devel_execute_form'),
     'access arguments' => array('execute php code'),
     'file' => 'devel.pages.inc',
   );
   $items['admin/devel/switch-user'] = array(
-    'title' => 'Switch user account',
-    'description' => 'Change the currently logged in user to another account.',
+    'title' => t('Switch user account'),
+    'description' => t('Change the currently logged in user to another account.'),
     'page callback' => 'backdrop_get_form',
     'page arguments' => array('devel_switch_user_form'),
     'access arguments' => array('switch users'),
   );
   // Redirect from easily-accessible settings page to the official location.
   $items['admin/devel/settings'] = array(
-    'title' => 'Devel settings',
-    'description' =>  'Configure query logging, XHProf, debugging messages, and other developer features.',
+    'title' => t('Devel settings'),
+    'description' => t('Configure query logging, XHProf, debugging messages, and other developer features.'),
     'page callback' => 'backdrop_goto',
     'page arguments' => array('admin/config/development/devel'),
     'access arguments' => array('administer site configuration'),
@@ -66,8 +66,8 @@ function devel_menu() {
    * Informational menu callbacks.
    */
   $items['admin/devel/info'] = array(
-    'title' => 'Information',
-    'description' => 'Deep inspection tools for Backdrop internals.',
+    'title' => t('Information'),
+    'description' => t('Deep inspection tools for Backdrop internals.'),
     'access arguments' => array('access devel information'),
     'page callback' => 'system_admin_menu_block_page',
     'weight' => 9,
@@ -76,43 +76,43 @@ function devel_menu() {
     'file path' => backdrop_get_path('module', 'system'),
   );
   $items['admin/devel/info/reference'] = array(
-    'title' => 'Function reference',
-    'description' => 'View a list of currently defined user functions with documentation links.',
+    'title' => t('Function reference'),
+    'description' => t('View a list of currently defined user functions with documentation links.'),
     'page callback' => 'devel_function_reference',
     'access arguments' => array('access devel information'),
     'file' => 'devel.pages.inc',
   );
   $items['admin/devel/info/theme'] = array(
-    'title' => 'Theme registry',
-    'description' => 'View a list of available theme functions across the whole site.',
+    'title' => t('Theme registry'),
+    'description' => t('View a list of available theme functions across the whole site.'),
     'page callback' => 'devel_theme_registry',
     'access arguments' => array('access devel information'),
     'file' => 'devel.pages.inc',
   );
   $items['admin/devel/info/entity'] = array(
-    'title' => 'Entity info',
-    'description' => 'View entity information across the whole site.',
+    'title' => t('Entity info'),
+    'description' => t('View entity information across the whole site.'),
     'page callback' => 'devel_entity_info_page',
     'access arguments' => array('access devel information'),
     'file' => 'devel.pages.inc',
   );
   $items['admin/devel/info/field'] = array(
-    'title' => 'Field info',
-    'description' => 'View fields information across the whole site.',
+    'title' => t('Field info'),
+    'description' => t('View fields information across the whole site.'),
     'page callback' => 'devel_field_info_page',
     'access arguments' => array('access devel information'),
     'file' => 'devel.pages.inc',
   );
   $items['admin/devel/info/elements'] = array(
-    'title' => 'Form API elements',
-    'description' => 'View the active form/render elements for this site.',
+    'title' => t('Form API elements'),
+    'description' => t('View the active form/render elements for this site.'),
     'page callback' => 'devel_elements_page',
     'access arguments' => array('access devel information'),
     'file' => 'devel.pages.inc',
   );
   $items['admin/devel/info/session'] = array(
-    'title' => 'Session viewer',
-    'description' => 'List the contents of $_SESSION.',
+    'title' => t('Session viewer'),
+    'description' => t('List the contents of <code>$_SESSION</code>.'),
     'page callback' => 'devel_session',
     'access arguments' => array('access devel information'),
     'file' => 'devel.pages.inc',
@@ -122,7 +122,7 @@ function devel_menu() {
    * Menu callbacks that are accessed directly without menu links.
    */
   $items['admin/devel/switch'] = array(
-    'title' => 'Switch user',
+    'title' => t('Switch user'),
     'page callback' => 'devel_switch_user',
     'access callback' => '_devel_switch_user_access',
     'access arguments' => array(2),
@@ -130,8 +130,8 @@ function devel_menu() {
     'type' => MENU_CALLBACK,
   );
   $items['admin/devel/menu/item'] = array(
-    'title' => 'Menu item',
-    'description' => 'Details about a given menu item.',
+    'title' => t('Menu item'),
+    'description' => t('Details about a given menu item.'),
     'page callback' => 'devel_menu_item',
     'access arguments' => array('access devel information'),
     'file' => 'devel.pages.inc',
@@ -139,24 +139,24 @@ function devel_menu() {
     'type' => MENU_CALLBACK,
   );
   $items['admin/devel/explain'] = array(
-    'title' => 'Explain query',
+    'title' => t('Explain query'),
+    'description' => t('Run an <code>EXPLAIN</code> on a given query. Used by query log'),
     'page callback' => 'devel_querylog_explain',
-    'description' => 'Run an EXPLAIN on a given query. Used by query log',
     'access arguments' => array('access devel information'),
     'file' => 'devel.pages.inc',
     'type' => MENU_CALLBACK
   );
   $items['admin/devel/arguments'] = array(
-    'title' => 'Arguments query',
+    'title' => t('Arguments query'),
+    'description' => t('Return a given query, with arguments instead of placeholders. Used by query log'),
     'page callback' => 'devel_querylog_arguments',
-    'description' => 'Return a given query, with arguments instead of placeholders. Used by query log',
     'access arguments' => array('access devel information'),
     'file' => 'devel.pages.inc',
     'type' => MENU_CALLBACK
   );
   $items['admin/config/development/devel'] = array(
-    'title' => 'Devel settings',
-    'description' =>  'Configure query logging, XHProf, debugging messages, and other developer features.',
+    'title' => t('Devel settings'),
+    'description' => t('Configure query logging, XHProf, debugging messages, and other developer features.'),
     'page callback' => 'backdrop_get_form',
     'page arguments' => array('devel_admin_settings'),
     'file' => 'devel.admin.inc',
@@ -167,7 +167,7 @@ function devel_menu() {
    * Information displayed as local tasks on various entities.
    */
   $items['node/%node/devel'] = array(
-    'title' => 'Devel',
+    'title' => t('Devel'),
     'page callback' => 'devel_load_object',
     'page arguments' => array('node', 1),
     'access arguments' => array('access devel information'),
@@ -176,11 +176,11 @@ function devel_menu() {
     'weight' => 100,
   );
   $items['node/%node/devel/load'] = array(
-    'title' => 'Load',
+    'title' => t('Load'),
     'type' => MENU_DEFAULT_LOCAL_TASK,
   );
   $items['node/%node/devel/render'] = array(
-    'title' => 'Render',
+    'title' => t('Render'),
     'page callback' => 'devel_render_object',
     'page arguments' => array('node', 1),
     'access arguments' => array('access devel information'),
@@ -189,7 +189,7 @@ function devel_menu() {
     'weight' => 100,
   );
   $items['comment/%comment/devel'] = array(
-    'title' => 'Devel',
+    'title' => t('Devel'),
     'page callback' => 'devel_load_object',
     'page arguments' => array('comment', 1),
     'access arguments' => array('access devel information'),
@@ -198,11 +198,11 @@ function devel_menu() {
     'weight' => 100,
   );
   $items['comment/%comment/devel/load'] = array(
-    'title' => 'Load',
+    'title' => t('Load'),
     'type' => MENU_DEFAULT_LOCAL_TASK,
   );
   $items['comment/%comment/devel/render'] = array(
-    'title' => 'Render',
+    'title' => t('Render'),
     'page callback' => 'devel_render_object',
     'page arguments' => array('comment', 1),
     'access arguments' => array('access devel information'),
@@ -211,7 +211,7 @@ function devel_menu() {
     'weight' => 100,
   );
   $items['user/%user/devel'] = array(
-    'title' => 'Devel',
+    'title' => t('Devel'),
     'page callback' => 'devel_load_object',
     'page arguments' => array('user', 1),
     'access arguments' => array('access devel information'),
@@ -220,11 +220,11 @@ function devel_menu() {
     'weight' => 100,
   );
   $items['user/%user/devel/load'] = array(
-    'title' => 'Load',
+    'title' => t('Load'),
     'type' => MENU_DEFAULT_LOCAL_TASK,
   );
   $items['user/%user/devel/render'] = array(
-    'title' => 'Render',
+    'title' => t('Render'),
     'page callback' => 'devel_render_object',
     'page arguments' => array('user', 1),
     'access arguments' => array('access devel information'),
@@ -233,7 +233,7 @@ function devel_menu() {
     'weight' => 100,
   );
   $items['taxonomy/term/%taxonomy_term/devel'] = array(
-    'title' => 'Devel',
+    'title' => t('Devel'),
     'page callback' => 'devel_load_object',
     'page arguments' => array('taxonomy_term', 2, 'term'),
     'access arguments' => array('access devel information'),
@@ -242,11 +242,11 @@ function devel_menu() {
     'weight' => 100,
   );
   $items['taxonomy/term/%taxonomy_term/devel/load'] = array(
-    'title' => 'Load',
+    'title' => t('Load'),
     'type' => MENU_DEFAULT_LOCAL_TASK,
   );
   $items['taxonomy/term/%taxonomy_term/devel/render'] = array(
-    'title' => 'Render',
+    'title' => t('Render'),
     'page callback' => 'devel_render_object',
     'page arguments' => array('taxonomy_term', 2, 'term'),
     'access arguments' => array('access devel information'),


### PR DESCRIPTION
See https://github.com/backdrop-contrib/devel/issues/49#issuecomment-508888707

I have started this branch in order to work on the changes from https://www.drupal.org/project/devel/issues/2653284 | https://git.drupalcode.org/project/devel/commit/66b409593700194623ed486fed58528ab85a68ec, but these are not applicable to the Backdrop version any longer.

This PR makes menu titles and descriptions translatable.