### PR TITLE
Use backdrop_substr instead of substr in krumo.

### DIFF
--- a/lib/krumo/class.krumo.php
+++ b/lib/krumo/class.krumo.php
@@ -1246,7 +1246,7 @@ This is a list of all the values from the <code><b><?php echo realpath($ini_file
     $_extra = false;
     $_ = $data;
     if (strLen($data) > KRUMO_TRUNCATE_LENGTH) {
-      $_ = substr($data, 0, KRUMO_TRUNCATE_LENGTH - 3) . '...';
+      $_ = backdrop_substr($data, 0, KRUMO_TRUNCATE_LENGTH - 3) . '...';
       $_extra = true;
       }
 ?>


### PR DESCRIPTION
https://www.drupal.org/project/devel/issues/2065225

https://git.drupalcode.org/project/devel/commit/48def5e3fee605a707213e41fdf5869032848799

https://github.com/backdrop-contrib/devel/issues/49

>Krumo calls `substr()` which breaks UTF-8 data.