### PR TITLE
Combined for both #85 and #87

### DIFF
--- a/devel.module
+++ b/devel.module
@@ -1411,8 +1411,8 @@ function devel_query_table($queries, $counts) {
   $version = devel_get_core_version(BACKDROP_VERSION);
   $header = array ('ms', '#', 'where', 'ops', 'query', 'target');
   $i = 0;
-  $api = config->get('api_url');
-  $slow_query_limit = config->get('query_slow_limit');
+  $api = config_get('api_url');
+  $slow_query_limit = config_get('query_slow_limit');
   $db_connection = Database::getconnection();
   foreach ($queries as $query) {
     $function = !empty($query['caller']['class']) ? $query['caller']['class'] . '::' : '';
@@ -1436,7 +1436,7 @@ function devel_query_table($queries, $counts) {
     }
     $cell[$i][] = implode(' ', $ops);
     // 3 divs for each variation of the query. Last 2 are hidden by default.
-    if (config->get('show_query_args_first')) {
+    if (config_get('show_query_args_first')) {
       $placeholders = '<div class="dev-placeholders" style="display: none;">' . check_plain($query['query']) . "</div>\n";
       $quoted = array();
       foreach ($query['args'] as $key => $val) {
@@ -1458,7 +1458,7 @@ function devel_query_table($queries, $counts) {
     $i++;
     unset($diff, $count, $ops);
   }
-  if (config->get('query_sort') === 'source') {
+  if (config_get('query_sort') === 'source') {
     usort($cell, '_devel_table_sort');
   }
   return theme('devel_querylog', array('header' => $header, 'rows' => $cell));

--- a/devel.module
+++ b/devel.module
@@ -1719,7 +1719,7 @@ function dprint_r($input, $return = FALSE, $name = NULL, $function = 'print_r', 
     if ($check) {
       $output = check_plain($output);
     }
-    if (count($input, COUNT_RECURSIVE) > DEVEL_MIN_TEXTAREA) {
+    if (is_array($input) && count($input, COUNT_RECURSIVE) > DEVEL_MIN_TEXTAREA) {
         // don't use fapi here because sometimes fapi will not be loaded
         $printed_value = "<textarea rows=30 style=\"width: 100%;\">\n". $name . $output .'</textarea>';
     }
@@ -1762,9 +1762,11 @@ function ddebug_backtrace($return = FALSE, $pop = 0) {
       array_shift($backtrace);
     }
     $counter = count($backtrace);
-    $path = $backtrace[$counter - 1]['file'];
-    $path = substr($path, 0, strlen($path) - 10);
-    $paths[$path] = strlen($path) + 1;
+    if (!empty($backtrace[$counter - 1]['file'])) {
+      $path = $backtrace[$counter - 1]['file'];
+      $path = substr($path, 0, strlen($path) - 10);
+      $paths[$path] = strlen($path) + 1;
+    }
     $paths[BACKDROP_ROOT] = strlen(BACKDROP_ROOT) + 1;
     $nbsp = "\xC2\xA0";
 

--- a/lib/krumo/class.krumo.php
+++ b/lib/krumo/class.krumo.php
@@ -1070,8 +1070,8 @@ This is a list of all the values from the <code><b><?php echo realpath($ini_file
 ?>
 <li class="krumo-child">
 
-  <div class="krumo-element<?php echo count($data) > 0 ? ' krumo-expand' : '';?>"
-    <?php if (count($data) > 0) {?> onClick="krumo.toggle(this);"<?php } ?>
+  <div class="krumo-element<?php echo !empty($data) ? ' krumo-expand' : '';?>"
+    <?php if (!empty($data)) {?> onClick="krumo.toggle(this);"<?php } ?>
     onMouseOver="krumo.over(this);"
     onMouseOut="krumo.out(this);">
 
@@ -1101,9 +1101,9 @@ This is a list of all the values from the <code><b><?php echo realpath($ini_file
 
   </div>
 
-  <?php if (count($data)) {
+  <?php 
     krumo::_vars($data);
-    } ?>
+    ?>
 </li>
 <?php
     }
@@ -1122,10 +1122,11 @@ This is a list of all the values from the <code><b><?php echo realpath($ini_file
 ?>
 <li class="krumo-child">
 
-  <div class="krumo-element<?php echo count($data) > 0 ? ' krumo-expand' : '';?>"
-    <?php if (count($data) > 0) {?> onClick="krumo.toggle(this);"<?php } ?>
+  <div class="krumo-element<?php echo !empty($data) ? ' krumo-expand' : '';?>"
+    <?php if (!empty($data)) {?> onClick="krumo.toggle(this);"<?php } ?>
     onMouseOver="krumo.over(this);"
     onMouseOut="krumo.out(this);">
+
 
       <?php /* DEVEL: added htmlSpecialChars */ ?>
       <a class="krumo-name"><?php echo htmlSpecialChars($name);?></a>
@@ -1133,9 +1134,9 @@ This is a list of all the values from the <code><b><?php echo realpath($ini_file
       <strong class="krumo-class"><?php echo get_class($data);?></strong>
   </div>
 
-  <?php if (count($data)) {
+  <?php
     krumo::_vars($data);
-    } ?>
+    ?>
 </li>
 <?php
     }


### PR DESCRIPTION
Fixes:
https://github.com/backdrop-contrib/devel/issues/85 `Error syntax error, unexpected '->' (T_OBJECT_OPERATOR)` 
https://github.com/backdrop-contrib/devel/issues/87 `ERROR: count(): Parameter must be an array or an object`