### PR TITLE
Issue #88: Syntax error, unexpected '=' in module_load_include()

### DIFF
--- a/devel_generate/modules/image.devel_generate.inc
+++ b/devel_generate/modules/image.devel_generate.inc
@@ -30,7 +30,7 @@ function _image_devel_generate($object, $field, $instance, $bundle) {
   // Generate a max of 5 different images.
   if (!isset($images[$extension][$min_resolution][$max_resolution]) || count($images[$extension][$min_resolution][$max_resolution]) <= DEVEL_GENERATE_IMAGE_MAX) {
     if ($path = devel_generate_image($extension, $min_resolution, $max_resolution)) {
-      destination_dir = $field['settings']['uri_scheme'] . '://' . $instance['settings']['file_directory'];
+      $destination_dir = $field['settings']['uri_scheme'] . '://' . $instance['settings']['file_directory'];
       file_prepare_directory($destination_dir, FILE_CREATE_DIRECTORY);
       if ($uri = file_unmanaged_move($path, $destination_dir)) {
         $file = new File();


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/devel/issues/88