### PR TITLE
Issue #123: Warning: mt_rand(): max(0) is smaller than min(1)

### DIFF
--- a/devel_generate/devel_generate.inc
+++ b/devel_generate/devel_generate.inc
@@ -152,6 +152,11 @@ function devel_generate_content($form_state) {
 }
 
 function devel_generate_add_comments($node, $users, $max_comments, $title_length = 8) {
+  // Exit early, if max comments was set to 0.
+  if ($max_comments == 0) {
+    return;
+  }
+
   $num_comments = mt_rand(1, $max_comments);
   for ($i = 1; $i <= $num_comments; $i++) {
     $comment = new Comment();


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/devel/issues/123