### PR TITLE
Add files to admin_paths

### DIFF
--- a/devel.module
+++ b/devel.module
@@ -302,6 +302,8 @@ function devel_admin_paths() {
     'user/*/devel/*' => TRUE,
     'taxonomy/term/*/devel' => TRUE,
     'taxonomy/term/*/devel/*' => TRUE,
+    'file/*/devel' => TRUE,
+    'file/*/devel/*' => TRUE,
   );
   return $paths;
 }


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/devel/issues/171

I was looking at a file using Devel and noticed the page looked different than a node in Devel. I realised it's because the file was using the default theme, instead of the admin theme like nodes use.

So this change adds files as admin_paths, like nodes.